### PR TITLE
Fix code scanning alert no. 59: Code injection

### DIFF
--- a/influent-client/src/main/requirejs/r.js
+++ b/influent-client/src/main/requirejs/r.js
@@ -218,8 +218,10 @@ var requirejs, require, define, xpcUtil;
 
         readFile = xpcUtil.readFile;
 
-        exec = function (string) {
-            return eval(string);
+        exec = function (config) {
+            if (typeof require === 'function') {
+                require.config(config);
+            }
         };
 
         exists = function (fileName) {
@@ -27800,7 +27802,7 @@ define('build', function (require) {
             dir.pop();
             dir = dir.join('/');
             //Make sure dir is JS-escaped, since it will be part of a JS string.
-            exec("require({baseUrl: '" + dir.replace(/[\\"']/g, '\\$&') + "'});");
+            exec({baseUrl: dir.replace(/[\\"']/g, '\\$&')});
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/drzo/influent/security/code-scanning/59](https://github.com/drzo/influent/security/code-scanning/59)

To fix the problem, we should avoid using `eval` to execute dynamically constructed code. Instead, we can use safer alternatives such as directly setting properties or using predefined functions. In this case, we can replace the `exec` function with a safer implementation that does not use `eval`.

- Replace the `exec` function to avoid using `eval`.
- Modify the `setBaseUrl` function to directly set the `baseUrl` without constructing a string for `eval`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
