### PR TITLE
Fix code scanning alert no. 65: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>maven-restlet</id>
 			<name>Public online Restlet repository</name>
-			<url>http://maven.restlet.org</url>
+			<url>https://maven.restlet.org</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Fixes [https://github.com/drzo/influent/security/code-scanning/65](https://github.com/drzo/influent/security/code-scanning/65)

To fix the problem, we need to change the repository URL from using the HTTP protocol to using the HTTPS protocol. This ensures that the communication between the Maven client and the repository server is encrypted, preventing potential MITM attacks.

- Locate the `<repository>` element in the `pom.xml` file.
- Change the `<url>` element from `http://maven.restlet.org` to `https://maven.restlet.org`.
- Ensure that the repository supports HTTPS. If it does not, consider using a different repository that supports secure communication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
